### PR TITLE
added this.props.replaceRoute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The **`this.props.toRoute()`** callback prop takes one parameter (a JavaScript o
 - `leftCornerProps`: if you set a `leftCorner` component you can use this property to pass props to that component.
 - `rightCornerProps`: if you set a `rightCorner` component you can use this property to pass props to that component.
 
+The **`this.props.replaceRoute`**  takes in an object that can contain the same keys as `toRoute()`. The difference is that instead of adding a route to your stack, it replaces the route
+that you're on with the new route that you pass it.
+- This is useful for login or signup screens. If you don't want your user to be able to navigate back to it, then use `replaceRoute()` rather than `toRoute()`.
+
 The **`this.props.setRightProps`** and **`this.props.setLeftProps`** take in an object of props and sends that to your navbar's `RightComponent` and `LeftComponent`.
 - This allows you to talk directly to your navbar, because previously you could only talk to it when navigating forward or backward.
 

--- a/index.js
+++ b/index.js
@@ -64,6 +64,11 @@ var Router = React.createClass({
       navigator.push(route);
     }.bind(this);
 
+    var replaceRoute = function(route) {
+      route.index = this.state.route.index || 0;
+      navigator.replace(route);
+    }.bind(this);
+
     var goBackwards = function() {
       this.onBack(navigator);
     }.bind(this);
@@ -134,6 +139,7 @@ var Router = React.createClass({
           data={route.data}
           toRoute={goForward}
           toBack={goBackwards}
+          replaceRoute={replaceRoute}
           reset={goToFirstRoute}
           setRightProps={setRightProps}
           setLeftProps={setLeftProps}


### PR DESCRIPTION
## Why

Wanted to have the ability to navigate somewhere, without the ability to return to the origin route. An example would be after logging in/signing up, if you don't want the user to be able to return to that route, then you use `replaceRoute` rather than `toRoute` when navigating away from the login.
## What

Added `this.props.replaceRoute()` which functions exactly like `this.props.toRoute()`. The only difference being that you whatever scene calls this method will no longer be in the route stack, and therefore cannot be navigated back to.

**For clarification:** if your route stack is `1 -> 2 -> 3` and you call `this.props.replaceRoute(4)` your stack will then be `1 -> 2 -> 4` 
## Issues

[#1](https://github.com/MikaelCarpenter/gb-native-router/issues/1)
