### PR TITLE
hideNavigationBar fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,8 @@ var Router = React.createClass({
 
     if(route.trans === true)
       var margin = 0
+    else if (this.props.hideNavigationBar === true)
+      var margin = 20
     else
       var margin = 64
 


### PR DESCRIPTION
## Why

`<Router hideNavigationBar=true />` would still leave content sitting 64 pixels below the top.
## What

Added a handler to set the proper margin if you're hiding the navigation bar.
## Issue

https://github.com/MikaelCarpenter/gb-native-router/issues/5
