### PR TITLE
added noStatusBar to <Router />

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ var Router = React.createClass({
     if(route.trans === true)
       var margin = 0
     else if (this.props.hideNavigationBar === true)
-      var margin = 20
+      var margin = this.props.noStatusBar ? 0 : 20
     else
       var margin = 64
 


### PR DESCRIPTION
## Why

If you hide statusBar and navBar, the content should sit at the top of the screen.
## What

Altered hideNavigationBar handler, so that if you also pass `noStatusBar=true` to `<Router />` the content will sit at the top. 

_In the future I want to also be able to move the navBar up so you can set `noStatusBar` without setting `hideNavigationBar`._
## Issue

https://github.com/MikaelCarpenter/gb-native-router/issues/5
