### PR TITLE
fix for long titles

### DIFF
--- a/components/NavBarContent.js
+++ b/components/NavBarContent.js
@@ -102,21 +102,13 @@ var NavBarContent = React.createClass({
      */
     var titleContent;
 
-    var routeName = this.props.route.name;
-
-    if (typeof routeName !== "undefined" && routeName !== null) {
-      if (routeName.length > 24) {
-        routeName = routeName.substring(0,21) + '...';
-      }
-    }
-
     if (this.props.route.titleComponent) {
       var TitleComponent = this.props.route.titleComponent;
       titleContent = <TitleComponent />;
     } else {
       titleContent = (
-        <Text style={[styles.navbarText, this.props.titleStyle]}>
-          {routeName}
+        <Text style={[styles.navbarText, this.props.titleStyle]} numberOfLines={1}>
+          {this.props.route.name}
         </Text>
       );
     }


### PR DESCRIPTION
## Why

Depending on the characters of your title, the `routeName` fix I had would still result in a second line.
## What

Got rid of `routeName` and using `numberOfLines` property for Text.
## Issue

[#10](https://github.com/MikaelCarpenter/gb-native-router/issues/10)
