### PR TITLE
Exposed scene config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,21 @@ The **`this.props.toRoute()`** callback prop takes one parameter (a JavaScript o
 - `leftCorner`: Specify a component to render on the left side of the navigation bar (like the "Add people"-button on the first page of the Twitter app)
 - `rightCorner`: Specify a component to render on the right side of the navigation bar
 - `titleComponent`: Specify a component to replace the title. This could for example be your logo (as in the first page of the Instagram app)
-- `headerStyle`: change the style of your header for the new route. You could for example specify a new backgroundColor and the router will automatically make a nice transition from one color to the other!
+- `headerStyle`: Change the style of your header for the new route. You could for example specify a new backgroundColor and the router will automatically make a nice transition from one color to the other!
 - `passProps`: Takes in an object. Passes each `key: value` pair to your component as a prop. i.e. <Component key={value} />
-- `trans`: if you set trans to `true` it will make the navbar transparent and move your component content so that it sits behind the nav.
-- `leftCornerProps`: if you set a `leftCorner` component you can use this property to pass props to that component.
-- `rightCornerProps`: if you set a `rightCorner` component you can use this property to pass props to that component.
+- `trans`: If you set trans to `true` it will make the navbar transparent and move your component content so that it sits behind the nav.
+- `leftCornerProps`: If you set a `leftCorner` component you can use this property to pass props to that component.
+- `rightCornerProps`: If you set a `rightCorner` component you can use this property to pass props to that component.
+- `sceneConfig`: Control the animation of the route being switched. Possible values are:
+  - Navigator.SceneConfigs.FadeAndroid
+  - Navigator.SceneConfigs.FloatFromBottom
+  - Navigator.SceneConfigs.FloatFromBottomAndroid
+  - Navigator.SceneConfigs.FloatFromLeft
+  - Navigator.SceneConfigs.FloatFromRight
+  - Navigator.SceneConfigs.HorizontalSwipeJump
+  - Navigator.SceneConfigs.PushFromRight
+  - Navigator.SceneConfigs.VerticalDownSwipeJump
+  - Navigator.SceneConfigs.VerticalUpSwipeJump
 
 The **`this.props.replaceRoute`**  takes in an object that can contain the same keys as `toRoute()`. The difference is that instead of adding a route to your stack, it replaces the route
 that you're on with the new route that you pass it.

--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ var Router = React.createClass({
     this.props.customAction(opts);
   },
 
+  configureScene: function(route) {
+    return route.sceneConfig || Navigator.SceneConfigs.FloatFromRight;
+  },
+
   renderScene: function(route, navigator) {
 
     var goForward = function(route) {
@@ -205,6 +209,7 @@ var Router = React.createClass({
         navigationBar={navigationBar}
         renderScene={this.renderScene}
         onWillFocus={this.onWillFocus}
+        configureScene={this.configureScene}
       />
     )
   }


### PR DESCRIPTION
## Why

Sometimes you need to be able to change the Navigator's animation. An example of this is the Twitter app's search view. Instead of "float from right" as per default, it simply fades in to provide a sense of responsiveness to the user.
## What

An option has been added to the route, sceneConfig which represents a config from Navigator.SceneConfigs (not very well documented). It defaults to Navigator.SceneConfigs.FloatFromRight.

The possible values (besides totally custom ones) are:
- Navigator.SceneConfigs.FadeAndroid (fades in, works on iOS too)
- Navigator.SceneConfigs.FloatFromBottom (modal like animation)
- Navigator.SceneConfigs.FloatFromBottomAndroid
- Navigator.SceneConfigs.FloatFromLeft
- Navigator.SceneConfigs.FloatFromRight (default for iOS)
- Navigator.SceneConfigs.HorizontalSwipeJump
- Navigator.SceneConfigs.PushFromRight
- Navigator.SceneConfigs.VerticalDownSwipeJump
- Navigator.SceneConfigs.VerticalUpSwipeJump

Example usage:

``` javascript
this.props.toRoute({
  name: "Search",
  titleComponent: SearchHeader,
  component: SearchComponent,
  sceneConfig: Navigator.SceneConfigs.FadeAndroid
});
```
