### PR TITLE
Adding resetToRoute API

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,11 @@ var Router = React.createClass({
       navigator.replace(route);
     }.bind(this);
 
+	  var resetToRoute = function(route) {
+      route.index = 0;
+      navigator.replace(route);
+    }.bind(this);
+
     var goBackwards = function() {
       this.onBack(navigator);
     }.bind(this);
@@ -127,6 +132,7 @@ var Router = React.createClass({
           toRoute={goForward}
           toBack={goBackwards}
           replaceRoute={replaceRoute}
+          resetToRoute={resetToRoute}
           reset={goToFirstRoute}
           setRightProps={setRightProps}
           setLeftProps={setLeftProps}

--- a/index.js
+++ b/index.js
@@ -95,31 +95,6 @@ var Router = React.createClass({
       this.customAction(opts);
     }.bind(this);
 
-    var didStartDrag = function(evt) {
-      var x = evt.nativeEvent.pageX;
-      if (x < 28) {
-        this.setState({
-          dragStartX: x,
-          didSwitchView: false
-        });
-        return true;
-      }
-    }.bind(this);
-
-    // Recognize swipe back gesture for navigation
-    var didMoveFinger = function(evt) {
-      var draggedAway = ((evt.nativeEvent.pageX - this.state.dragStartX) > 30);
-      if (!this.state.didSwitchView && draggedAway) {
-        this.onBack(navigator);
-        this.setState({ didSwitchView: true });
-      }
-    }.bind(this);
-
-    // Set to false to prevent iOS from hijacking the responder
-    var preventDefault = function(evt) {
-      return true;
-    };
-
     var Content = route.component;
 
     // Remove the margin of the navigation bar if not using navigation bar
@@ -139,9 +114,6 @@ var Router = React.createClass({
     return (
       <View
         style={[styles.container, this.props.bgStyle, extraStyling, {marginTop: margin}]}
-        onStartShouldSetResponder={didStartDrag}
-        onResponderMove={didMoveFinger}
-        onResponderTerminationRequest={preventDefault}>
         <Content
           name={route.name}
           index={route.index}


### PR DESCRIPTION
This API resets the current stack to 0, and thus can be used in deeper routes to begin again with a brand new navigator stack.

I created it so that replaceRoute can be used to replace the current route and maintain the previous navigator stack, and resetToRoute can be used to replace the current route and also start over with a blank navigator stack. 

This means that "back" navigations will be gone.
